### PR TITLE
1. Addition of CouponPayingSecurity to represent instruments that pay…

### DIFF
--- a/bt/__init__.py
+++ b/bt/__init__.py
@@ -3,7 +3,9 @@ from . import algos
 from . import backtest
 
 from .backtest import Backtest, run
-from .core import Strategy, Algo, AlgoStack
+from .core import Strategy, Algo, AlgoStack, FixedIncomeStrategy
+from .core import Security, FixedIncomeSecurity, CouponPayingSecurity
+from .core import HedgeSecurity, CouponPayingHedgeSecurity
 
 import ffn
 from ffn import utils, data, get, merge


### PR DESCRIPTION
… coupons/accrue interest, where the coupons are passed in as data

2. Optional usage of bid/offer spread when transacting, where the spread is passed in as optional data (separate from the existing commissions functionality, which should be used in conjunction to represent venue fees)
3. Addition of FixedIncomeStrategy (and FixedIncomeInstrument), where
  a. Weights are based off of notional value rather than market value (i.e. $100MM of bonds)
  b. Strategy price is computed from additive PNL returns (rather than multiplicative returns)
  c. Securities are bought/sold on a fixed-quantity basis rather than based on capital allocation
  d. Addition of HedgeSecurity, which are just like regular securities, except the “notional value” used for weighting in fixed income strategies is zero. i.e. The strategy/weighting is defined in terms of notional of primary instruments, not hedges.
4. Small bug fixes and improvements – most notably doing float comparisons with some tolerance to account for float precision issues